### PR TITLE
fixed permissions for changing user passwords

### DIFF
--- a/django/account/admin.py
+++ b/django/account/admin.py
@@ -58,7 +58,11 @@ class UserAdmin(DjangoUserAdmin):
         return False
 
     def has_change_permission(self, request, obj=None):
-        return False
+        # Only allow changes to the password
+        if '/password/' in request.get_full_path():
+            return True
+        else:
+            return False
 
     def has_delete_permission(self, request, obj=None):
         return False


### PR DESCRIPTION
Users shouldn't be edited via the dashboard, apart from their passwords. This PR fixes the issue whereby passwords couldn't be changed via the admin dashboard.