### PR TITLE
django 4.2 upgrade

### DIFF
--- a/.github/workflows/ci-django-tests.yml
+++ b/.github/workflows/ci-django-tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.10.4]
+        python-version: [3.10.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci-flake8.yml
+++ b/.github/workflows/ci-flake8.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.10.4]
+        python-version: [3.10.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci-pa11y.yml
+++ b/.github/workflows/ci-pa11y.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.10.4]
+        python-version: [3.10.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/django/core/local_settings.example.py
+++ b/django/core/local_settings.example.py
@@ -20,14 +20,6 @@ RECAPTCHA_PRIVATE_KEY = ''
 # Set to True if in development, or False is in production
 DEBUG = True/False
 
-# Set static file storage.
-# In live, use ManifestStaticFilesStorage with DEBUG set to False
-# In other environments, use StaticFilesStorage with DEBUG set to True
-if DEBUG is True:
-    STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.StaticFilesStorage'
-else:
-    STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.ManifestStaticFilesStorage'
-
 # Set to ['*'] if in development, or specific IP addresses and domains if in production
 ALLOWED_HOSTS = ['*']/['languages-for-all-digital-first.bham.ac.uk']
 

--- a/django/core/local_settings.test.py
+++ b/django/core/local_settings.test.py
@@ -17,11 +17,6 @@ RECAPTCHA_PRIVATE_KEY = ''
 
 DEBUG = True
 
-if DEBUG is True:
-    STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.StaticFilesStorage'
-else:
-    STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.ManifestStaticFilesStorage'
-
 ALLOWED_HOSTS = ['*']
 
 DATABASES = {

--- a/django/core/settings.py
+++ b/django/core/settings.py
@@ -9,7 +9,6 @@ TEMPLATE_DIR = os.path.join(BASE_DIR, 'core/templates')
 # Application definition
 
 INSTALLED_APPS = [
-    'django_light',  # must be before django.contrib.admin
     # Default Django
     'django.contrib.admin',
     'django.contrib.auth',
@@ -105,8 +104,6 @@ TIME_ZONE = 'Europe/London'
 
 USE_I18N = False  # Set to True if using internationalisation (translations) in your project
 
-USE_L10N = True
-
 USE_TZ = True
 
 
@@ -139,3 +136,17 @@ except ImportError:
 # Ensure the SECRET_KEY is supplied in local_settings.py - and trust that the other settings are there too.
 if not SECRET_KEY:  # NOQA
     sys.exit('Missing SECRET_KEY in local_settings.py')
+
+
+# Storages
+
+# Default STORAGES from Django documentation
+# See: https://docs.djangoproject.com/en/4.2/ref/settings/#std-setting-STORAGES
+STORAGES = {
+    "default": {"BACKEND": "django.core.files.storage.FileSystemStorage"},
+    "staticfiles": {"BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage"},
+}
+
+# Use ManifestStaticFilesStorage when not in debug mode
+if not DEBUG:  # NOQA
+    STORAGES['staticfiles'] = {"BACKEND": "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"}

--- a/django/core/templates/admin/base_site.html
+++ b/django/core/templates/admin/base_site.html
@@ -24,4 +24,5 @@
         <a href="{% url 'admin:password_change' %}">{% translate 'Change password' %}</a> /
     {% endif %}
     <a href="{% url 'admin:logout' %}">{% translate 'Log out' %}</a>
+    {% include "admin/color_theme_toggle.html" %}
 {% endblock %}

--- a/django/exercises/forms.py
+++ b/django/exercises/forms.py
@@ -1,5 +1,6 @@
 from django import forms
-from captcha.fields import ReCaptchaField, ReCaptchaV3
+from captcha.fields import ReCaptchaField
+from captcha.widgets import ReCaptchaV3
 from . import models
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,13 @@
 # Please follow suitable version specifiers, as outlined in https://www.python.org/dev/peps/pep-0440/#version-specifiers
 # For Django versioning we use ~= (e.g. Django~=3.2.0) which will keep the minor version up to date (e.g. the latest version prior to 3.3.0)
 
-Django~=3.2.0
-psycopg2~=2.9.2
-pytz~=2022.1
+Django~=4.2.0
+psycopg~=3.1.8
 flake8~=4.0.1
 Pillow~=9.1.0
 gunicorn~=20.1.0
-django-recaptcha~=2.0
+django-recaptcha~=3.0.0
 django-embed-video~=1.4.0
-django-light~=0.1.0
 pandas~=1.4.3
 openpyxl~=3.0.10
 XlsxWriter~=3.0.3


### PR DESCRIPTION
Upgrades Django from 3.2 to 4.2 and makes associated changes required elsewhere as part of this upgrade

Remember that the local settings file will need to be updated on all machines, e.g. test and live VMs